### PR TITLE
Bump js-codepage to version 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "codepage": "~1.3.4",
+    "codepage": "~1.4.0",
     "utfx": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest version of js-codepage makes it work with latest versions of
node. Reflect this in srt2vtt.

SheetJS/js-codepage@8bc8da47b

Should fix #6
